### PR TITLE
Don't require HMDA_Data_Science_Kit to be directory name + README cleanup

### DIFF
--- a/load_scripts/SQL/create_and_load_lar_2004.sql
+++ b/load_scripts/SQL/create_and_load_lar_2004.sql
@@ -47,7 +47,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2004.dat';
+FROM '{data_path}/data/lar/lar_2004.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2005.sql
+++ b/load_scripts/SQL/create_and_load_lar_2005.sql
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2005.dat';
+FROM '{data_path}/data/lar/lar_2005.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2006.sql
+++ b/load_scripts/SQL/create_and_load_lar_2006.sql
@@ -47,7 +47,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2006.dat';
+FROM '{data_path}/data/lar/lar_2006.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2007.sql
+++ b/load_scripts/SQL/create_and_load_lar_2007.sql
@@ -47,7 +47,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2007.dat';
+FROM '{data_path}/data/lar/lar_2007.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2008.sql
+++ b/load_scripts/SQL/create_and_load_lar_2008.sql
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2008.dat';
+FROM '{data_path}/data/lar/lar_2008.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2009.sql
+++ b/load_scripts/SQL/create_and_load_lar_2009.sql
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2009.dat';
+FROM '{data_path}/data/lar/lar_2009.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2010.sql
+++ b/load_scripts/SQL/create_and_load_lar_2010.sql
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2010.dat';
+FROM '{data_path}/data/lar/lar_2010.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2011.sql
+++ b/load_scripts/SQL/create_and_load_lar_2011.sql
@@ -47,7 +47,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2011.dat';
+FROM '{data_path}/data/lar/lar_2011.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2012.sql
+++ b/load_scripts/SQL/create_and_load_lar_2012.sql
@@ -47,7 +47,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2012.dat';
+FROM '{data_path}/data/lar/lar_2012.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2013.sql
+++ b/load_scripts/SQL/create_and_load_lar_2013.sql
@@ -45,7 +45,7 @@ CREATE TEMPORARY TABLE lar_load
 
 COPY lar_load
 -- Change this path to your local data path.
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2013.dat';
+FROM '{data_path}/data/lar/lar_2013.dat';
 
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_lar_2014.sql
+++ b/load_scripts/SQL/create_and_load_lar_2014.sql
@@ -48,5 +48,5 @@ CREATE TABLE hmda_public.lar_2014 (
 );
 
 COPY hmda_public.lar_2014
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2014.csv'
+FROM '{data_path}/data/lar/lar_2014.csv'
     DELIMITER ',' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_lar_2015.sql
+++ b/load_scripts/SQL/create_and_load_lar_2015.sql
@@ -48,5 +48,5 @@ CREATE TABLE hmda_public.lar_2015 (
 );
 
 COPY hmda_public.lar_2015
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2015.csv'
+FROM '{data_path}/data/lar/lar_2015.csv'
     DELIMITER ',' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_lar_2016.sql
+++ b/load_scripts/SQL/create_and_load_lar_2016.sql
@@ -48,5 +48,5 @@ CREATE TABLE hmda_public.lar_2016 (
 );
 
 COPY hmda_public.lar_2016
-FROM '{data_path}HMDA_Data_Science_Kit/data/lar/lar_2016.csv'
+FROM '{data_path}/data/lar/lar_2016.csv'
     DELIMITER ',' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_lar_2017.sql
+++ b/load_scripts/SQL/create_and_load_lar_2017.sql
@@ -47,7 +47,7 @@ CREATE TABLE lar_2017 (
     application_date_indicator VARCHAR);
 
 COPY hmda_public.lar_2017
-FROM '/Users/roellk/HMDA/HMDA_Data_Science_Kit/data/lar/lar_2017.txt'
+FROM '{data_path}/data/lar/lar_2017.txt'
 DELIMITER '|' ENCODING 'latin1';
 
 

--- a/load_scripts/SQL/create_and_load_panel_2004.sql
+++ b/load_scripts/SQL/create_and_load_panel_2004.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2004 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2004.dat' 
+FROM '{data_path}/data/panel/panel_2004.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2004 (

--- a/load_scripts/SQL/create_and_load_panel_2005.sql
+++ b/load_scripts/SQL/create_and_load_panel_2005.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2005 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2005.dat' 
+FROM '{data_path}/data/panel/panel_2005.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2005 (

--- a/load_scripts/SQL/create_and_load_panel_2006.sql
+++ b/load_scripts/SQL/create_and_load_panel_2006.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2006 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2006.dat' 
+FROM '{data_path}/data/panel/panel_2006.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2006 (

--- a/load_scripts/SQL/create_and_load_panel_2007.sql
+++ b/load_scripts/SQL/create_and_load_panel_2007.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2007 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2007.dat' 
+FROM '{data_path}/data/panel/panel_2007.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2007 (

--- a/load_scripts/SQL/create_and_load_panel_2008.sql
+++ b/load_scripts/SQL/create_and_load_panel_2008.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2008 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2008.dat' 
+FROM '{data_path}/data/panel/panel_2008.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2008 (

--- a/load_scripts/SQL/create_and_load_panel_2009.sql
+++ b/load_scripts/SQL/create_and_load_panel_2009.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2009 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2009.dat' 
+FROM '{data_path}/data/panel/panel_2009.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2009 (

--- a/load_scripts/SQL/create_and_load_panel_2010.sql
+++ b/load_scripts/SQL/create_and_load_panel_2010.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2010 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2010.dat' 
+FROM '{data_path}/data/panel/panel_2010.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2010 (

--- a/load_scripts/SQL/create_and_load_panel_2011.sql
+++ b/load_scripts/SQL/create_and_load_panel_2011.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2011 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2011.dat' 
+FROM '{data_path}/data/panel/panel_2011.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2011 (

--- a/load_scripts/SQL/create_and_load_panel_2012.sql
+++ b/load_scripts/SQL/create_and_load_panel_2012.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2012 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2012.dat' 
+FROM '{data_path}/data/panel/panel_2012.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2012 (

--- a/load_scripts/SQL/create_and_load_panel_2013.sql
+++ b/load_scripts/SQL/create_and_load_panel_2013.sql
@@ -20,7 +20,7 @@ CREATE TABLE hmda_public.panel_2013 (
   (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
         --Change to your local path
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2013.dat' 
+FROM '{data_path}/data/panel/panel_2013.dat' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2013 (

--- a/load_scripts/SQL/create_and_load_panel_2014.sql
+++ b/load_scripts/SQL/create_and_load_panel_2014.sql
@@ -27,7 +27,7 @@ CREATE TABLE hmda_public.panel_2014 (
  CREATE TEMPORARY TABLE panel_load
     (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2014.txt' 
+FROM '{data_path}/data/panel/panel_2014.txt' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2014 (

--- a/load_scripts/SQL/create_and_load_panel_2015.sql
+++ b/load_scripts/SQL/create_and_load_panel_2015.sql
@@ -27,7 +27,7 @@ CREATE TABLE hmda_public.panel_2015 (
  CREATE TEMPORARY TABLE panel_load
     (PANEL VARCHAR); -- LAR contains an entire LAR record
  COPY panel_load
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2015.txt' 
+FROM '{data_path}/data/panel/panel_2015.txt' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2015 (

--- a/load_scripts/SQL/create_and_load_panel_2016.sql
+++ b/load_scripts/SQL/create_and_load_panel_2016.sql
@@ -29,7 +29,7 @@ CREATE TABLE hmda_public.panel_2016 (
     (PANEL VARCHAR); -- LAR contains an entire LAR record
 
 COPY panel_load
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2016.txt' 
+FROM '{data_path}/data/panel/panel_2016.txt' 
     ENCODING 'latin1';
 COMMIT;
  INSERT INTO hmda_public.panel_2016 (

--- a/load_scripts/SQL/create_and_load_panel_2017.sql
+++ b/load_scripts/SQL/create_and_load_panel_2017.sql
@@ -23,6 +23,6 @@ CREATE TABLE hmda_public.panel_2017 (
 	respondent_state_fips VARCHAR);
 
 COPY hmda_public.panel_2017
-FROM '{data_path}HMDA_Data_Science_Kit/data/panel/panel_2017.txt' 
+FROM '{data_path}/data/panel/panel_2017.txt' 
 	DELIMITER '|' ENCODING 'latin1';
 COMMIT;

--- a/load_scripts/SQL/create_and_load_ts_2004.sql
+++ b/load_scripts/SQL/create_and_load_ts_2004.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2004.dat' 
+FROM '{data_path}/data/ts/ts_2004.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2005.sql
+++ b/load_scripts/SQL/create_and_load_ts_2005.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2005.dat' 
+FROM '{data_path}/data/ts/ts_2005.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2006.sql
+++ b/load_scripts/SQL/create_and_load_ts_2006.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2006.dat' 
+FROM '{data_path}/data/ts/ts_2006.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2007.sql
+++ b/load_scripts/SQL/create_and_load_ts_2007.sql
@@ -22,7 +22,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2007.dat' 
+FROM '{data_path}/data/ts/ts_2007.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2008.sql
+++ b/load_scripts/SQL/create_and_load_ts_2008.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2008.dat' 
+FROM '{data_path}/data/ts/ts_2008.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2009.sql
+++ b/load_scripts/SQL/create_and_load_ts_2009.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2009.dat' 
+FROM '{data_path}/data/ts/ts_2009.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2010.sql
+++ b/load_scripts/SQL/create_and_load_ts_2010.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2010.dat' 
+FROM '{data_path}/data/ts/ts_2010.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2011.sql
+++ b/load_scripts/SQL/create_and_load_ts_2011.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2011.dat' 
+FROM '{data_path}/data/ts/ts_2011.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2012.sql
+++ b/load_scripts/SQL/create_and_load_ts_2012.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2012.dat' 
+FROM '{data_path}/data/ts/ts_2012.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2013.sql
+++ b/load_scripts/SQL/create_and_load_ts_2013.sql
@@ -21,7 +21,7 @@ CREATE TEMPORARY TABLE ts_load
 
 COPY ts_load 
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2013.dat' 
+FROM '{data_path}/data/ts/ts_2013.dat' 
     ENCODING 'latin1';
 COMMIT;
 

--- a/load_scripts/SQL/create_and_load_ts_2014.sql
+++ b/load_scripts/SQL/create_and_load_ts_2014.sql
@@ -26,5 +26,5 @@ CREATE TABLE ts_2014(
 
 COPY hmda_public.ts_2014
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2014.txt'
+FROM '{data_path}/data/ts/ts_2014.txt'
 	DELIMITER E'\t' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_ts_2015.sql
+++ b/load_scripts/SQL/create_and_load_ts_2015.sql
@@ -26,5 +26,5 @@ CREATE TABLE hmda_public.ts_2015(
 
 COPY hmda_public.ts_2015
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2015.txt'
+FROM '{data_path}/data/ts/ts_2015.txt'
 	DELIMITER E'\t' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_ts_2016.sql
+++ b/load_scripts/SQL/create_and_load_ts_2016.sql
@@ -26,5 +26,5 @@ CREATE TABLE hmda_public.ts_2016(
 
 COPY hmda_public.ts_2016
 -- Change to your local data path
-FROM '{data_path}HMDA_Data_Science_Kit/data/ts/ts_2016_fixed.txt'
+FROM '{data_path}/data/ts/ts_2016_fixed.txt'
 	DELIMITER E'\t' ENCODING 'latin1';

--- a/load_scripts/SQL/create_and_load_ts_2017.sql
+++ b/load_scripts/SQL/create_and_load_ts_2017.sql
@@ -19,6 +19,6 @@ CREATE TABLE hmda_public.ts_2017 (
 
 COPY hmda_public.ts_2017
 FROM 
-'{data_path}HMDA_Data_Science_Kit/data/ts/ts_2017.txt'
+'{data_path}/data/ts/ts_2017.txt'
     DELIMITER '|' ENCODING 'latin1';
 COMMIT;

--- a/load_scripts/reset_path.py
+++ b/load_scripts/reset_path.py
@@ -4,13 +4,16 @@ from os import listdir
 from os.path import isfile, join
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-dir_path = dir_path[:-34]
+# Back up to the base HMDA_Data_Science_Kit directory
+dir_path = os.path.realpath(os.path.join(dir_path, ".."))
+#dir_path = dir_path[:-34]
 #print(dir_path)
 text_to_search = dir_path
-text_to_search = text_to_search.replace("HMDA", "hmda")
 replacement_text = '{data_path}'
 
-mypath = dir_path+"HMDA_Data_Science_Kit/load_scripts/SQL/"
+mypath = os.path.join(dir_path, "load_scripts/SQL/")
+print(mypath)
+
 onlyfiles = [f for f in listdir(mypath) if isfile(join(mypath, f))]
 ts_files = [mypath+f for f in onlyfiles if f[-11:-9]=="ts"]
 lar_files = [mypath+f for f in onlyfiles if f[-12:-9]=="lar"]

--- a/load_scripts/write_data_paths.sh
+++ b/load_scripts/write_data_paths.sh
@@ -2,11 +2,8 @@
 
 #get current directory path
 data_path=$PWD
-#remove HMDA_Data_Science from path
-path_remove=${data_path:${#data_path} - 21}
-replace_path=${data_path%"$path_remove"}
 
-#iterate over files in load_scripts/SQL and change {data_path} to the directory above HMDA_Data_Science
+#iterate over files in load_scripts/SQL and change {data_path} to the HMDA_Data_Science_Kit base directory
 for filename in load_scripts/SQL/*.sql; do
 	#get year of file for filtering files
 	substr=${filename:${#filename} - 8}
@@ -16,7 +13,7 @@ for filename in load_scripts/SQL/*.sql; do
 	#modify data path
 	if [[ $year =~ $re ]] ; then
    		echo "Modifying data path for $filename"
-   		sed -i '' "s+{data_path}+${replace_path}+g" $filename
+   		sed -i '' "s+{data_path}+${data_path}+g" $filename
 	fi
 	
 

--- a/readme.md
+++ b/readme.md
@@ -167,12 +167,12 @@ This change can be undone by running the following:
 
 ### Quickstart
 
-To download all supported HMDA data, unzip any zipped data, and add the data to a Postgres database, you'll run the following commands in order.
+To download all supported HMDA data, unzip any zipped data, and add the data to a Postgres database, you'll run the following commands in order:
 
 ```
 bash download_scripts/download_hmda.sh
 bash download_scripts/unzip_all.sh
-bash load_scripts/create_hmda_db.sh
+bash load_scripts/create_and_load_hmda.sh
 ```
 
 After the downloading step, you'll need to check if all files successfully downloaded. [See above for more information](#download-troubleshooting).

--- a/readme.md
+++ b/readme.md
@@ -168,12 +168,12 @@ This change can be undone by running the following:
 
 ### Quickstart
 
-To download the data, unzip the data, and add it to the Postgres database
+To download all supported HMDA data, unzip any zipped data, and add the data to a Postgres database, you'll run the following commands in order.
 
 ```
 bash download_scripts/download_hmda.sh
 bash download_scripts/unzip_all.sh
-bash load_scripts/create_and_load_lar_2004_2017.sh
-bash load_scripts/create_and_load_ts_2004_2017.sh
-bash load_scripts/create_andload_panel_2004_2017.sh
+bash load_scripts/create_hmda_db.sh
 ```
+
+After the downloading step, you'll need to check if all files successfully downloaded. [See above for more information](#download-troubleshooting).

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,5 @@
 **Table of Contents:**
+
 - [Repository purpose and scope](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#repository-purpose-and-scope)
 - [What is HMDA](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#what-is-hmda)
 - [HMDA Datasets](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#hmda-datasets)
@@ -9,12 +10,12 @@
 - [Working With HMDA Data](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#working-with-hmda-data)
 - [Getting Started: Basic Requirements](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#basic-requirements-and-instructions)
 
+## Repository Purpose and Scope:
 
-
-#### Repository Purpose and Scope:
 The primary goal of this repository is to provide data users with tools to enable them to produce accurate analytics results. Additionally, this repository provides an overview of HMDA resources, publications, and guidelines for proper use. This repository does not provide statutory interpretation or compliance assistance. 
 
-#### What Is HMDA?
+## What Is HMDA?
+
 HMDA refers to the [Home Mortgage Disclosure Act of 1975](https://www.gpo.gov/fdsys/pkg/USCODE-2011-title12/pdf/USCODE-2011-title12-chap29.pdf).
 HMDA requires many financial institutions to maintain, report, and publicly disclose loan-level information about mortgages. HMDA was originally enacted by Congress in 1975 and is implemented by [Regulation C](https://www.consumerfinance.gov/policy-compliance/rulemaking/final-rules/regulation-c-home-mortgage-disclosure-act/). 
 
@@ -22,12 +23,14 @@ Congress amended HMDA in 2010 and the Bureau finalized a rule implementing chang
 
 The senate bill S2155 modified some reporting requirements for the 2018 data collection. These changes will be outlined in upcoming publications.
 
-**What is the purpose of HMDA?**
+#### What is the purpose of HMDA?
+
 - To provide the public with information that will help show whether financial institutions are serving the housing credit needs of the neighborhoods and communities in which they are located. 
 - To aid public officials in targeting public investments from the private sector to areas where they are needed. 
 - The FIRREA amendments of 1989 require the collection and disclosure of data about applicant and borrower characteristics to assist in identifying possible discriminatory lending patterns and enforcing antidiscrimination statutes.
 
-#### HMDA Datasets
+## HMDA Datasets
+
 Three raw data files are published annually under HMDA authority. File formats (and schemas) vary by data source. The National Archives (NARA) use a .DAT format, the FFIEC site maintained by the Federal Reserve Board (FRB) use a .CSV format (with Census data appended) and the FFIEC site maintained by the BCFP us a pipe-delimited .TXT format (with Census data appended). Links to HMDA datasets are available in this [file](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/hmda_data_links.md).
 
 These datasets include:
@@ -37,13 +40,14 @@ These datasets include:
 
 - The HMDA Reporter Panel: This dataset contains additional information regarding financial institutions such as identifier links to the National Information Center (NIC) and hierarchy information such as parent and top holder. The HMDA Reporter Panel is assembled by the Bureau on behalf of the FFIEC (beginning in 2017). Panel schemas can be found in this [folder]().
 
+## Integration of Census Data with HMDA
 
-#### Integration of Census Data with HMDA
 HMDA data is often joined to Census data to show context for the mortgage data. The FFIEC joins the following to the HMDA LAR data: area population, minority population percentage, FFIEC median family income, tract to MSA/MD median family income percentage, number of owner-occupied units, and the number of 1-4 family units. These data are joined at the tract level to provide context for mortgage activity in the relevant geography. The base data for this join are made available by the FFIEC on this [website](https://www.ffiec.gov/censusapp.htm). The year of the Census data correspond to the HMDA collection year. 
 
 For examples on how to handle Census data and join Census data to LAR data please see the [Census directory]().
 
-#### HMDA Data Documentation
+## HMDA Data Documentation
+
 - [2018 Filing Instruction Guide (FIG)](https://www.consumerfinance.gov/data-research/hmda/static/for-filers/2018/2018-hmda-fig.pdf): Outlines the file format, data fields, business rules, and valid values for data submitted in 2018.
 - [2017 Filing Instruction Guide (FIG)](https://www.consumerfinance.gov/data-research/hmda/static/for-filers/2017/2017-hmda-fig.pdf): Outlines the the file format, data fields, business rules, and valid values for data submitted in 2017.
 - [BCFP Small Entity Compliance Guide](https://s3.amazonaws.com/files.consumerfinance.gov/f/documents/cfpb_hmda_small-entity-compliance-guide.pdf): The purpose of this guide is to provide an easy-to-use summary of Regulation C, as amended by the HMDA Rule, and to highlight information that financial institutions and those that work with them might find helpful when implementing the HMDA Rule.
@@ -54,16 +58,18 @@ For examples on how to handle Census data and join Census data to LAR data pleas
 - [2018 Transaction Coverage](https://s3.amazonaws.com/files.consumerfinance.gov/f/documents/201709_cfpb_2018-hmda-institutional-coverage.pdf): Outlines which transactions are covered by Regulation C.
 - [HMDA Loan Scenarios](https://www.consumerfinance.gov/data-research/hmda/static/for-filers/HMDA-Loan-Scenarios.pdf): Fictional scenarios designed to assist in compilation of LAR data to meet requirements under Regulation C.
 
-#### Working With HMDA Data
+## Working With HMDA Data
+
 The HMDA data are complex and care must be taken to ensure that analytics results are accurate. Please see [Working With HMDA Data]() for explanations of how to load, segment the data, handle NA values, and create accurate time-series tabulations.
 
-#### HMDA Publications
+## HMDA Publications
+
 For a list of HMDA publications, see [here](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/federal_pubs.md)
   
+## Basic Requirements and Instructions
 
-#### Basic Requirements and Instructions
+### Requirements
 
-#### Requirements
 The resources in this repository assume that a database has been installed and is functioning properly. The SQL code is written for [PostgreSQL](https://www.postgresql.org/), other SQL versions may require modification to the code. 
 
 The Python resources assume that a functioning installation of [Python 3.5 or greater](https://www.python.org/downloads/) or greater is present. Convention in these instructions and code resources will use python3 to invoke python scripts. If two versions of Python are not present, this command may need to be changed to python, without the 3.
@@ -71,7 +77,8 @@ The Python resources assume that a functioning installation of [Python 3.5 or gr
 This repository has a requirements.txt file that can be used to install the Python libraries used in the repository:
 - `pip install -r requirements.txt` 
 
-#### Downloading and Unzipping Data
+### Downloading and Unzipping Data
+
 To begin using the HMDA data you will first need to download the data. A list of data resources is available in [HMDA data links](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/hmda_data_links.md).
 
 These data can be downloaded manually from the links listed or the following script can be run from the HMDA_Data_Science_Kit directory:  
@@ -82,50 +89,53 @@ The script can download HMDA ultimate data files for LAR, Transmittal Sheet, and
 Running the script without flags will download all LAR, Transmittal Sheet, and Panel files that are not present. 
 
 The script accepts the following option flags:
-- -a: Prints to console the available files for download. 
-- -s: Allows a specific file to be downloaded if it is not present. The name convention for specific files is as follows: lar_<year>, panel_<year>, or ts_<year>.
-- -p: Downloads all Panel files that are not present.
-- -t: Downloads all Transmittal Sheet files that are not present.
-- -l: Downloads all LAR files that are not present.
-- -F: Deletes the file or file types to be downloaded (the files are then redownloaded).
-- -h: Prints to console the instructions for using the script.
+- `-a`: Prints to console the available files for download. 
+- `-s`: Allows a specific file to be downloaded if it is not present. The name convention for specific files is as follows: lar_<year>, panel_<year>, or ts_<year>.
+- `-p`: Downloads all Panel files that are not present.
+- `-t`: Downloads all Transmittal Sheet files that are not present.
+- `-l`: Downloads all LAR files that are not present.
+- `-F`: Deletes the file or file types to be downloaded (the files are then redownloaded).
+- `-h`: Prints to console the instructions for using the script.
 
-Usage examples:
-To download LAR files: `bash download_scripts/download_hmda.sh -l`
-To download Panel files: `bash download_scripts/download_hmda.sh -p`
-To download Transmittal Sheet files: `bash download_scripts/download_hmda.sh -t`
-To download a specific file: `bash download_scripts/download_hmda.sh -s filename`
-To delete and download Panel files: `bash download_scripts/download_hmda.sh -Fp`
-To delete and download a specific file: `bash download_scripts/download_hmda.sh -Fs filename`
-To delete and download LAR 2004: `bash download_scripts/download_hmda.sh -Fs lar_2004`
+#### Usage examples
 
-Download Troubleshooting:
+- To download LAR files: `bash download_scripts/download_hmda.sh -l`
+- To download Panel files: `bash download_scripts/download_hmda.sh -p`
+- To download Transmittal Sheet files: `bash download_scripts/download_hmda.sh -t`
+- To download a specific file: `bash download_scripts/download_hmda.sh -s filename`
+- To delete and download Panel files: `bash download_scripts/download_hmda.sh -Fp`
+- To delete and download a specific file: `bash download_scripts/download_hmda.sh -Fs filename`
+- To delete and download LAR 2004: `bash download_scripts/download_hmda.sh -Fs lar_2004`
+
+#### Download Troubleshooting
+
 Sometimes files from the National Archives fail to download correctly. An indicator that this happens is the presence of a file with the correct name (such as LAR_20013.zip) that has a filesize of 4kb. In these cases the file must be deleted and redownloaded. One way to do this is:
  - `bash download_scripts/download_hmda.sh -Fs <filename>`.
 
-Unzipping Compressed Files:
+**Unzipping Compressed Files**
+
 All of the LAR files, and several of the Panel and Transmittal Sheets download as zip files. Prior to loading these data the files must be unzipped. To do so, run the following script:
 - `bash download_scripts/unzip_all.sh`
 
 The above script will unzip all the zipped files and standardize the names of the files.
 
 Alternatively, the LAR, Panel, and Transmittal Sheet files can be unzipped as groups using the following commands:
+
 - `bash download_scripts/unzip_and_rename_lar.sh`
 - `bash download_scripts/unzip_panel.sh`
 - `bash download_scripts/unzip_ts.sh`
-
 
 ### Creating Postgres Tables and Loading Data
 
 The default installation of Postgres should create both a Postgres role (superuser account) and a Postgres database. The default behavior of the load scripts uses these for login. If the role or the database are not present then a user and/or database will need to be specified when running the load scripts. Examples are provided later in this section.
 
 Available option flags for the load scripts are as follows:
-- -u: Sets the user role for the Postgres connection, default is postgres.
-- -p: Sets the password for the Postgres connection, default is blank.
-- -d: Sets the database for connection, default is postgres.
-- -h: Sets the database host, default is localhost.
-- -o: Sets the database connection port, the default is 5432.
-- --help: Displays the options available for the script.
+- `-u`: Sets the user role for the Postgres connection, default is postgres.
+- `-p`: Sets the password for the Postgres connection, default is blank.
+- `-d`: Sets the database for connection, default is postgres.
+- `-h`: Sets the database host, default is localhost.
+- `-o`: Sets the database connection port, the default is 5432.
+- `--help`: Displays the options available for the script.
 
 The script below creates a HMDA database on an existing Postgres installation, creates the hmda_public schema, creates tables, and loads data:
 - `bash load_scripts/create_hmda_db.sh`
@@ -135,7 +145,8 @@ To load subsets of the HMDA data (LAR, Transmittal Sheet, or Panel) use the scri
 - `bash load_scripts/create_and_load_ts_2004_2017.sh`
 - `bash load_scripts/create_andload_panel_2004_2017.sh`
 
-Using Options Flags:
+#### Using Options Flags
+
 All of the load scripts support the same option flags. The example below use the create_hmda_db.sh script, but any script can be substituted.
 
 To specify a username:
@@ -150,13 +161,19 @@ To specify a database:
 To specify a username and password:
 - `bash load_scripts/create_hmda_db.sh -u <username> -p <password>`
 
-
 The SQL scripts provided in HMDA_Data_Science_Kit/load_scripts/SQL require an update to the path for the data sources before they can be used. The placeholder is {data_path}. This placeholder is replaced with the full path to the HMDA data when any of the load scripts are run. For example {data_path}HMDA_Data_Science_Kit/data/lar/lar_ult_2004.dat' on a Mac will become /Users/<username>/HMDA_Data_Science_Kit/data/lar/lar_ult_2004.dat'.
 
 This change can be undone by running the following:
 - `python3 load_scripts/reset_path.py`
 
+### Quickstart
 
+To download the data, unzip the data, and add it to the Postgres database
 
-
-
+```
+bash download_scripts/download_hmda.sh
+bash download_scripts/unzip_all.sh
+bash load_scripts/create_and_load_lar_2004_2017.sh
+bash load_scripts/create_and_load_ts_2004_2017.sh
+bash load_scripts/create_andload_panel_2004_2017.sh
+```

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,13 @@
-**Table of Contents:**
+### Table of Contents
 
-- [Repository purpose and scope](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#repository-purpose-and-scope)
-- [What is HMDA](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#what-is-hmda)
-- [HMDA Datasets](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#hmda-datasets)
-- [Integration of Census Data with HMDA](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#integration-of-census-data-with-hmda)
-
-- [Official HMDA documentation](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#hmda-data-documentation)
-- [Official HMDA data publications](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#hmda-publications)
-- [Working With HMDA Data](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#working-with-hmda-data)
-- [Getting Started: Basic Requirements](https://github.com/cfpb/HMDA_Data_Science_Kit/blob/master/readme.md#basic-requirements-and-instructions)
+- [Repository purpose and scope](#repository-purpose-and-scope)
+- [What is HMDA](#what-is-hmda)
+- [HMDA Datasets](#hmda-datasets)
+- [Integration of Census Data with HMDA](#integration-of-census-data-with-hmda)
+- [Official HMDA documentation](#hmda-data-documentation)
+- [Official HMDA data publications](#hmda-publications)
+- [Working With HMDA Data](#working-with-hmda-data)
+- [Getting Started: Basic Requirements](#basic-requirements-and-instructions)
 
 ## Repository Purpose and Scope:
 


### PR DESCRIPTION
Thanks for providing this, it's a heck of a lot more useful than downloading the files one at a time and massaging them together!

If you download the zip of the repo instead of cloning it, your code will end up in a directory named `HMDA_Data_Science_Kit-master`. Running `write_data_paths.sh` would then fail to write correct paths to the SQL because it adjusts the path based on a specific number of characters. To fix this I adjusted the script + SQL to work even if the base directory isn't `HMDA_Data_Science_Kit`.

The path reset script has been adjusted to work with these changes.

I also fixed `create_and_load_lar_2017.sql` which had someone's personal path in it.

Finally, I cleaned up the README, adding leveled headers to help with accessibility + added a Quickstart at the bottom (it was easy to miss some of the steps in all of the text). Apologies that the documentation changes aren't in a separate PR.