### PR TITLE
Missing column definition for LAR 2009 SQL import script

### DIFF
--- a/load_scripts/SQL/create_and_load_lar_2009.sql
+++ b/load_scripts/SQL/create_and_load_lar_2009.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS hmda_public.lar_2009;
 CREATE TABLE hmda_public.lar_2009(   
-    activity_year,
+    activity_year VARCHAR,
     respondent_id VARCHAR,
     agency_code VARCHAR,
     loan_type VARCHAR,


### PR DESCRIPTION
It looks like `activity_year` in the 2009 import script is missing a `VARCHAR` definition. Thanks!